### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,6 @@
 name: Build
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/SheepReaper/IHeartFiction/security/code-scanning/3](https://github.com/SheepReaper/IHeartFiction/security/code-scanning/3)

To fix this issue, explicitly limit the permissions available to the GITHUB_TOKEN in the workflow. You can do this by adding a `permissions:` block either at the workflow root level or per job. The minimal, recommended starting point is `contents: read`, which allows actions to read repository contents but not write or perform additional privileged operations. Since there is just one job in this example, include `permissions:` either immediately after the workflow name or directly under the job definition (`build:`). To catch all jobs and avoid copy-pasting if more jobs are later added, the best practice is to put `permissions:` at the top workflow level (just after `name:` and before or after `on:`). No imports, methods, or definitions are required—simply add the appropriate YAML block for permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
