### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/labeler-cache-retention.yml
+++ b/.github/workflows/labeler-cache-retention.yml
@@ -3,6 +3,8 @@
 #
 # Regularly restore the prediction models from cache to prevent cache eviction
 name: "Labeler: Cache Retention"
+permissions:
+  contents: read
 
 # For more information about GitHub's action cache limits and eviction policy, see:
 # https://docs.github.com/actions/writing-workflows/choosing-what-your-workflow-does/caching-dependencies-to-speed-up-workflows#usage-limits-and-eviction-policy


### PR DESCRIPTION
Potential fix for [https://github.com/SheepReaper/IHeartFiction/security/code-scanning/4](https://github.com/SheepReaper/IHeartFiction/security/code-scanning/4)

To fix the issue, you must explicitly add a `permissions` block to limit the default permissions granted to the workflow. This block should be added at the top level (immediately under the workflow `name:` and before `on:`), or at the job level if different jobs require different permissions. In this case, since there is only one job and its steps do not appear to require write access, you should set `permissions` for the workflow to read-only with `contents: read`. This ensures that the workflow’s GITHUB_TOKEN has only the minimum access needed.

**How to fix:**
- Add a `permissions` block with `contents: read` immediately after the `name:` key in the workflow file.

**Where to edit:**  
- File: `.github/workflows/labeler-cache-retention.yml`
- Insert the block after line 5 (after the `name: "Labeler: Cache Retention"` line).

**What is needed:**  
- No new imports or external dependencies.
- No methods or code changes outside the YAML edit.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
