### PR TITLE
Refactor integration test service setup

### DIFF
--- a/tests/IHFiction.IntegrationTests/Authors/AsNoTrackingBugTests.cs
+++ b/tests/IHFiction.IntegrationTests/Authors/AsNoTrackingBugTests.cs
@@ -1,13 +1,11 @@
 using System.Security.Claims;
 
-using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Diagnostics;
-using Microsoft.Extensions.DependencyInjection;
-
-using IHFiction.Data;
 using IHFiction.Data.Authors.Domain;
 using IHFiction.Data.Contexts;
 using IHFiction.FictionApi.Common;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace IHFiction.IntegrationTests.Authors;
 
@@ -174,14 +172,7 @@ public class AsNoTrackingBugTests : BaseIntegrationTest, IConfigureServices<AsNo
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "xUnit1013:Public method should be marked as test", Justification = "This method implements IConfigureServices<T>")]
     public static void ConfigureServices(IServiceCollection services)
     {
-        services.AddKeyedScoped(
-            nameof(AsNoTrackingBugTests),
-            (sp, key) => new FictionDbContext(new DbContextOptionsBuilder<FictionDbContext>()
-                .UseNpgsql(sp.GetRequiredService<PgsqlConnectionStringProvider>().GetConnectionStringForDatabase($"test_{nameof(AsNoTrackingBugTests)}"))
-                .UseSnakeCaseNamingConvention()
-                .ConfigureWarnings(w => w.Log(RelationalEventId.PendingModelChangesWarning))
-                .WithDefaultInterceptors(sp.GetRequiredService<TimeProvider>())
-                .Options));
+        services.AddKeyedTestFictionDbContext<AsNoTrackingBugTests>();
     }
 
     public async ValueTask InitializeAsync()

--- a/tests/IHFiction.IntegrationTests/Authors/AuthorInterceptorTests.cs
+++ b/tests/IHFiction.IntegrationTests/Authors/AuthorInterceptorTests.cs
@@ -1,12 +1,10 @@
-using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Diagnostics;
-using Microsoft.Extensions.DependencyInjection;
-
 using FluentAssertions;
 
-using IHFiction.Data;
 using IHFiction.Data.Authors.Domain;
 using IHFiction.Data.Contexts;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace IHFiction.IntegrationTests.Authors;
 
@@ -277,14 +275,7 @@ public class AuthorInterceptorTests : BaseIntegrationTest, IConfigureServices<Au
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "xUnit1013:Public method should be marked as test", Justification = "This method implements IConfigureServices<T>")]
     public static void ConfigureServices(IServiceCollection services)
     {
-        services.AddKeyedScoped(
-            nameof(AuthorInterceptorTests),
-            (sp, key) => new FictionDbContext(new DbContextOptionsBuilder<FictionDbContext>()
-                .UseNpgsql(sp.GetRequiredService<PgsqlConnectionStringProvider>().GetConnectionStringForDatabase($"test_{nameof(AuthorInterceptorTests)}"))
-                .UseSnakeCaseNamingConvention()
-                .ConfigureWarnings(w => w.Log(RelationalEventId.PendingModelChangesWarning))
-                .WithDefaultInterceptors(sp.GetRequiredService<TimeProvider>())
-                .Options));
+        services.AddKeyedTestFictionDbContext<AuthorInterceptorTests>();
     }
 
     public async ValueTask InitializeAsync()

--- a/tests/IHFiction.IntegrationTests/Authors/AuthorMigrationTests.cs
+++ b/tests/IHFiction.IntegrationTests/Authors/AuthorMigrationTests.cs
@@ -1,12 +1,10 @@
-using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Diagnostics;
-using Microsoft.Extensions.DependencyInjection;
-
 using FluentAssertions;
 
-using IHFiction.Data;
 using IHFiction.Data.Authors.Domain;
 using IHFiction.Data.Contexts;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace IHFiction.IntegrationTests.Authors;
 
@@ -228,14 +226,7 @@ public class AuthorMigrationTests : BaseIntegrationTest, IConfigureServices<Auth
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "xUnit1013:Public method should be marked as test", Justification = "This method implements IConfigureServices<T>")]
     public static void ConfigureServices(IServiceCollection services)
     {
-        services.AddKeyedScoped(
-            nameof(AuthorMigrationTests),
-            (sp, key) => new FictionDbContext(new DbContextOptionsBuilder<FictionDbContext>()
-                .UseNpgsql(sp.GetRequiredService<PgsqlConnectionStringProvider>().GetConnectionStringForDatabase($"test_{nameof(AuthorMigrationTests)}"))
-                .UseSnakeCaseNamingConvention()
-                .ConfigureWarnings(w => w.Log(RelationalEventId.PendingModelChangesWarning))
-                .WithDefaultInterceptors(sp.GetRequiredService<TimeProvider>())
-                .Options));
+        services.AddKeyedTestFictionDbContext<AuthorMigrationTests>();
     }
 
     public async ValueTask InitializeAsync()

--- a/tests/IHFiction.IntegrationTests/Authors/EntityTrackingTests.cs
+++ b/tests/IHFiction.IntegrationTests/Authors/EntityTrackingTests.cs
@@ -1,15 +1,12 @@
 using System.Security.Claims;
 
-using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Diagnostics;
-using Microsoft.Extensions.DependencyInjection;
-
-using IHFiction.Data;
 using IHFiction.Data.Authors.Domain;
 using IHFiction.Data.Contexts;
-using IHFiction.FictionApi.Authors;
-using IHFiction.FictionApi.Common;
 using IHFiction.FictionApi.Account;
+using IHFiction.FictionApi.Common;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace IHFiction.IntegrationTests.Authors;
 
@@ -217,14 +214,7 @@ public class EntityTrackingTests : BaseIntegrationTest, IConfigureServices<Entit
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "xUnit1013:Public method should be marked as test", Justification = "This method implements IConfigureServices<T>")]
     public static void ConfigureServices(IServiceCollection services)
     {
-        services.AddKeyedScoped(
-            nameof(EntityTrackingTests),
-            (sp, key) => new FictionDbContext(new DbContextOptionsBuilder<FictionDbContext>()
-                .UseNpgsql(sp.GetRequiredService<PgsqlConnectionStringProvider>().GetConnectionStringForDatabase($"test_{nameof(EntityTrackingTests)}"))
-                .UseSnakeCaseNamingConvention()
-                .ConfigureWarnings(w => w.Log(RelationalEventId.PendingModelChangesWarning))
-                .WithDefaultInterceptors(sp.GetRequiredService<TimeProvider>())
-                .Options));
+        services.AddKeyedTestFictionDbContext<EntityTrackingTests>();
     }
 
     public async ValueTask InitializeAsync()

--- a/tests/IHFiction.IntegrationTests/Authors/GetAuthorDatabaseSpecificTests.cs
+++ b/tests/IHFiction.IntegrationTests/Authors/GetAuthorDatabaseSpecificTests.cs
@@ -1,14 +1,12 @@
-using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Diagnostics;
-using Microsoft.Extensions.DependencyInjection;
-
 using FluentAssertions;
 
-using IHFiction.Data;
 using IHFiction.Data.Authors.Domain;
 using IHFiction.Data.Contexts;
 using IHFiction.FictionApi.Authors;
 using IHFiction.FictionApi.Common;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace IHFiction.IntegrationTests.Authors;
 
@@ -258,15 +256,8 @@ public class GetAuthorDatabaseSpecificTests : BaseIntegrationTest, IConfigureSer
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "xUnit1013:Public method should be marked as test", Justification = "This method implements IConfigureServices<T>")]
     public static void ConfigureServices(IServiceCollection services)
     {
-        services.AddKeyedScoped(
-            nameof(GetAuthorDatabaseSpecificTests),
-            (sp, key) => new FictionDbContext(new DbContextOptionsBuilder<FictionDbContext>()
-                .UseNpgsql(sp.GetRequiredService<PgsqlConnectionStringProvider>().GetConnectionStringForDatabase($"test_{nameof(GetAuthorDatabaseSpecificTests)}"), options =>
-                    options.UseQuerySplittingBehavior(QuerySplittingBehavior.SplitQuery))
-                .UseSnakeCaseNamingConvention()
-                .ConfigureWarnings(w => w.Log(RelationalEventId.PendingModelChangesWarning))
-                .WithDefaultInterceptors(sp.GetRequiredService<TimeProvider>())
-                .Options));
+        services.AddKeyedTestFictionDbContext<GetAuthorDatabaseSpecificTests>(options =>
+            options.UseQuerySplittingBehavior(QuerySplittingBehavior.SplitQuery));
     }
 
     public async ValueTask InitializeAsync()

--- a/tests/IHFiction.IntegrationTests/Authors/GetAuthorEdgeCaseTests.cs
+++ b/tests/IHFiction.IntegrationTests/Authors/GetAuthorEdgeCaseTests.cs
@@ -1,15 +1,13 @@
-using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Diagnostics;
-using Microsoft.Extensions.DependencyInjection;
-
 using FluentAssertions;
 
-using IHFiction.Data;
 using IHFiction.Data.Authors.Domain;
 using IHFiction.Data.Contexts;
 using IHFiction.Data.Stories.Domain;
 using IHFiction.FictionApi.Authors;
 using IHFiction.FictionApi.Common;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace IHFiction.IntegrationTests.Authors;
 
@@ -392,14 +390,7 @@ public class GetAuthorEdgeCaseTests : BaseIntegrationTest, IConfigureServices<Ge
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "xUnit1013:Public method should be marked as test", Justification = "This method implements IConfigureServices<T>")]
     public static void ConfigureServices(IServiceCollection services)
     {
-        services.AddKeyedScoped(
-            nameof(GetAuthorEdgeCaseTests),
-            (sp, key) => new FictionDbContext(new DbContextOptionsBuilder<FictionDbContext>()
-                .UseNpgsql(sp.GetRequiredService<PgsqlConnectionStringProvider>().GetConnectionStringForDatabase($"test_{nameof(GetAuthorEdgeCaseTests)}"))
-                .UseSnakeCaseNamingConvention()
-                .ConfigureWarnings(w => w.Log(RelationalEventId.PendingModelChangesWarning))
-                .WithDefaultInterceptors(sp.GetRequiredService<TimeProvider>())
-                .Options));
+        services.AddKeyedTestFictionDbContext<GetAuthorEdgeCaseTests>();
     }
 
     public async ValueTask InitializeAsync()

--- a/tests/IHFiction.IntegrationTests/Authors/GetAuthorIntegrationTests.cs
+++ b/tests/IHFiction.IntegrationTests/Authors/GetAuthorIntegrationTests.cs
@@ -1,15 +1,13 @@
-using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Diagnostics;
-using Microsoft.Extensions.DependencyInjection;
-
 using FluentAssertions;
 
-using IHFiction.Data;
 using IHFiction.Data.Authors.Domain;
 using IHFiction.Data.Contexts;
 using IHFiction.Data.Stories.Domain;
 using IHFiction.FictionApi.Authors;
 using IHFiction.FictionApi.Common;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace IHFiction.IntegrationTests.Authors;
 
@@ -292,14 +290,7 @@ public class GetAuthorIntegrationTests : BaseIntegrationTest, IConfigureServices
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "xUnit1013:Public method should be marked as test", Justification = "This method implements IConfigureServices<T>")]
     public static void ConfigureServices(IServiceCollection services)
     {
-        services.AddKeyedScoped(
-            nameof(GetAuthorIntegrationTests),
-            (sp, key) => new FictionDbContext(new DbContextOptionsBuilder<FictionDbContext>()
-                .UseNpgsql(sp.GetRequiredService<PgsqlConnectionStringProvider>().GetConnectionStringForDatabase($"test_{nameof(GetAuthorIntegrationTests)}"))
-                .UseSnakeCaseNamingConvention()
-                .ConfigureWarnings(w => w.Log(RelationalEventId.PendingModelChangesWarning))
-                .WithDefaultInterceptors(sp.GetRequiredService<TimeProvider>())
-                .Options));
+        services.AddKeyedTestFictionDbContext<GetAuthorIntegrationTests>();
     }
 
     public async ValueTask InitializeAsync()

--- a/tests/IHFiction.IntegrationTests/Authors/GetAuthorTests.cs
+++ b/tests/IHFiction.IntegrationTests/Authors/GetAuthorTests.cs
@@ -1,15 +1,13 @@
-using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Diagnostics;
-using Microsoft.Extensions.DependencyInjection;
-
 using FluentAssertions;
 
-using IHFiction.Data;
 using IHFiction.Data.Authors.Domain;
 using IHFiction.Data.Contexts;
 using IHFiction.Data.Stories.Domain;
 using IHFiction.FictionApi.Authors;
 using IHFiction.FictionApi.Common;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace IHFiction.IntegrationTests.Authors;
 
@@ -356,14 +354,7 @@ public class GetAuthorTests : BaseIntegrationTest, IConfigureServices<GetAuthorT
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "xUnit1013:Public method should be marked as test", Justification = "This method implements IConfigureServices<T>")]
     public static void ConfigureServices(IServiceCollection services)
     {
-        services.AddKeyedScoped(
-            nameof(GetAuthorTests),
-            (sp, key) => new FictionDbContext(new DbContextOptionsBuilder<FictionDbContext>()
-                .UseNpgsql(sp.GetRequiredService<PgsqlConnectionStringProvider>().GetConnectionStringForDatabase($"test_{nameof(GetAuthorTests)}"))
-                .UseSnakeCaseNamingConvention()
-                .ConfigureWarnings(w => w.Log(RelationalEventId.PendingModelChangesWarning))
-                .WithDefaultInterceptors(sp.GetRequiredService<TimeProvider>())
-                .Options));
+        services.AddKeyedTestFictionDbContext<GetAuthorTests>();
     }
 
     public async ValueTask InitializeAsync()

--- a/tests/IHFiction.IntegrationTests/Authors/ListAuthorsTests.cs
+++ b/tests/IHFiction.IntegrationTests/Authors/ListAuthorsTests.cs
@@ -1,15 +1,13 @@
-using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Diagnostics;
-using Microsoft.Extensions.DependencyInjection;
-
 using FluentAssertions;
 
-using IHFiction.Data;
 using IHFiction.Data.Authors.Domain;
 using IHFiction.Data.Contexts;
 using IHFiction.Data.Stories.Domain;
 using IHFiction.FictionApi.Authors;
 using IHFiction.FictionApi.Infrastructure;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace IHFiction.IntegrationTests.Authors;
 
@@ -163,14 +161,7 @@ public class ListAuthorsTests : BaseIntegrationTest, IConfigureServices<ListAuth
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "xUnit1013:Public method should be marked as test", Justification = "This method implements IConfigureServices<T>")]
     public static void ConfigureServices(IServiceCollection services)
     {
-        services.AddKeyedScoped(
-            nameof(ListAuthorsTests),
-            (sp, key) => new FictionDbContext(new DbContextOptionsBuilder<FictionDbContext>()
-                .UseNpgsql(sp.GetRequiredService<PgsqlConnectionStringProvider>().GetConnectionStringForDatabase($"test_{nameof(ListAuthorsTests)}"))
-                .UseSnakeCaseNamingConvention()
-                .ConfigureWarnings(w => w.Log(RelationalEventId.PendingModelChangesWarning))
-                .WithDefaultInterceptors(sp.GetRequiredService<TimeProvider>())
-                .Options));
+        services.AddKeyedTestFictionDbContext<ListAuthorsTests>();
     }
 
     public async ValueTask InitializeAsync()

--- a/tests/IHFiction.IntegrationTests/Authors/UpdateAuthorProfileIntegrationTests.cs
+++ b/tests/IHFiction.IntegrationTests/Authors/UpdateAuthorProfileIntegrationTests.cs
@@ -2,15 +2,13 @@ using System.Net;
 using System.Net.Http.Json;
 using System.Security.Claims;
 
-using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Diagnostics;
-using Microsoft.Extensions.DependencyInjection;
-
-using IHFiction.Data;
 using IHFiction.Data.Authors.Domain;
 using IHFiction.Data.Contexts;
 using IHFiction.FictionApi.Account;
 using IHFiction.FictionApi.Common;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace IHFiction.IntegrationTests.Authors;
 
@@ -290,14 +288,7 @@ Visit my [website](https://example.com) for more info!";
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "xUnit1013:Public method should be marked as test", Justification = "This method implements IConfigureServices<T>")]
     public static void ConfigureServices(IServiceCollection services)
     {
-        services.AddKeyedScoped(
-            nameof(UpdateAuthorProfileIntegrationTests),
-            (sp, key) => new FictionDbContext(new DbContextOptionsBuilder<FictionDbContext>()
-                .UseNpgsql(sp.GetRequiredService<PgsqlConnectionStringProvider>().GetConnectionStringForDatabase($"test_{nameof(UpdateAuthorProfileIntegrationTests)}"))
-                .UseSnakeCaseNamingConvention()
-                .ConfigureWarnings(w => w.Log(RelationalEventId.PendingModelChangesWarning))
-                .WithDefaultInterceptors(sp.GetRequiredService<TimeProvider>())
-                .Options));
+        services.AddKeyedTestFictionDbContext<UpdateAuthorProfileIntegrationTests>();
     }
 
     public async ValueTask InitializeAsync()

--- a/tests/IHFiction.IntegrationTests/IntegrationTestServiceCollectionExtensions.cs
+++ b/tests/IHFiction.IntegrationTests/IntegrationTestServiceCollectionExtensions.cs
@@ -1,0 +1,60 @@
+using IHFiction.Data;
+using IHFiction.Data.Contexts;
+using IHFiction.Data.Stories.Domain;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.DependencyInjection;
+
+using MongoDB.Driver;
+
+using Npgsql.EntityFrameworkCore.PostgreSQL.Infrastructure;
+
+namespace IHFiction.IntegrationTests;
+
+internal static class IntegrationTestServiceCollectionExtensions
+{
+    public static IServiceCollection AddKeyedTestFictionDbContext<TTest>(
+        this IServiceCollection services,
+        Action<NpgsqlDbContextOptionsBuilder>? configureNpgsql = null,
+        bool configurePendingModelWarning = true,
+        bool useDefaultInterceptors = true)
+    {
+        services.AddKeyedScoped(
+            typeof(TTest).Name,
+            (sp, key) =>
+            {
+                var connectionString = sp.GetRequiredService<PgsqlConnectionStringProvider>()
+                    .GetConnectionStringForDatabase($"test_{typeof(TTest).Name}");
+
+                var builder = new DbContextOptionsBuilder<FictionDbContext>()
+                    .UseNpgsql(connectionString, options => configureNpgsql?.Invoke(options))
+                    .UseSnakeCaseNamingConvention();
+
+                if (configurePendingModelWarning)
+                {
+                    builder.ConfigureWarnings(w => w.Log(RelationalEventId.PendingModelChangesWarning));
+                }
+
+                if (useDefaultInterceptors)
+                {
+                    builder.WithDefaultInterceptors(sp.GetRequiredService<TimeProvider>());
+                }
+
+                return new FictionDbContext(builder.Options);
+            });
+
+        return services;
+    }
+
+    public static IServiceCollection AddKeyedTestWorkBodyCollection<TTest>(this IServiceCollection services)
+    {
+        services.AddKeyedScoped(
+            typeof(TTest).Name,
+            (sp, key) => sp.GetRequiredService<IMongoClient>()
+                .GetDatabase($"test_stories_{typeof(TTest).Name}")
+                .GetCollection<WorkBody>("works"));
+
+        return services;
+    }
+}

--- a/tests/IHFiction.IntegrationTests/Stories/ConvertStoryTypeIntegrationTests.cs
+++ b/tests/IHFiction.IntegrationTests/Stories/ConvertStoryTypeIntegrationTests.cs
@@ -1,10 +1,10 @@
-using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.DependencyInjection;
-
 using IHFiction.Data.Contexts;
 using IHFiction.Data.Stories.Domain;
 using IHFiction.FictionApi.Common;
 using IHFiction.FictionApi.Stories;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
 
 using MongoDB.Bson;
 using MongoDB.Driver;
@@ -89,18 +89,9 @@ public sealed class ConvertStoryTypeIntegrationTests : BaseIntegrationTest, ICon
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "xUnit1013:Public method should be marked as test", Justification = "This method implements IConfigureServices<T>")]
     public static void ConfigureServices(IServiceCollection services)
     {
-        services.AddKeyedScoped(
-            nameof(ConvertStoryTypeIntegrationTests),
-            (sp, key) => new FictionDbContext(new DbContextOptionsBuilder<FictionDbContext>()
-                .UseNpgsql(sp.GetRequiredService<PgsqlConnectionStringProvider>().GetConnectionStringForDatabase($"test_{nameof(ConvertStoryTypeIntegrationTests)}"))
-                .UseSnakeCaseNamingConvention()
-                .Options));
-
-        services.AddKeyedScoped(
-            nameof(ConvertStoryTypeIntegrationTests),
-            (sp, key) => sp.GetRequiredService<IMongoClient>()
-                .GetDatabase($"test_stories_{nameof(ConvertStoryTypeIntegrationTests)}")
-                .GetCollection<WorkBody>("works"));
+        services
+            .AddKeyedTestFictionDbContext<ConvertStoryTypeIntegrationTests>(configurePendingModelWarning: false, useDefaultInterceptors: false)
+            .AddKeyedTestWorkBodyCollection<ConvertStoryTypeIntegrationTests>();
     }
 
     public async ValueTask InitializeAsync()

--- a/tests/IHFiction.IntegrationTests/Stories/GetOwnBookContentIntegrationTests.cs
+++ b/tests/IHFiction.IntegrationTests/Stories/GetOwnBookContentIntegrationTests.cs
@@ -1,13 +1,13 @@
 using System.Security.Claims;
 
-using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.DependencyInjection;
-
 using IHFiction.Data.Authors.Domain;
 using IHFiction.Data.Contexts;
 using IHFiction.Data.Stories.Domain;
 using IHFiction.FictionApi.Account;
 using IHFiction.FictionApi.Common;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
 
 using MongoDB.Driver;
 
@@ -116,18 +116,9 @@ public sealed class GetOwnBookContentIntegrationTests : BaseIntegrationTest, ICo
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "xUnit1013:Public method should be marked as test", Justification = "This method implements IConfigureServices<T>")]
     public static void ConfigureServices(IServiceCollection services)
     {
-        services.AddKeyedScoped(
-            nameof(GetOwnBookContentIntegrationTests),
-            (sp, key) => new FictionDbContext(new DbContextOptionsBuilder<FictionDbContext>()
-                .UseNpgsql(sp.GetRequiredService<PgsqlConnectionStringProvider>().GetConnectionStringForDatabase($"test_{nameof(GetOwnBookContentIntegrationTests)}"))
-                .UseSnakeCaseNamingConvention()
-                .Options));
-
-        services.AddKeyedScoped(
-            nameof(GetOwnBookContentIntegrationTests),
-            (sp, key) => sp.GetRequiredService<IMongoClient>()
-                .GetDatabase($"test_stories_{nameof(GetOwnBookContentIntegrationTests)}")
-                .GetCollection<WorkBody>("works"));
+        services
+            .AddKeyedTestFictionDbContext<GetOwnBookContentIntegrationTests>(configurePendingModelWarning: false, useDefaultInterceptors: false)
+            .AddKeyedTestWorkBodyCollection<GetOwnBookContentIntegrationTests>();
     }
 
     public async ValueTask InitializeAsync()

--- a/tests/IHFiction.IntegrationTests/Stories/UpdateStoryContentMarkdownTests.cs
+++ b/tests/IHFiction.IntegrationTests/Stories/UpdateStoryContentMarkdownTests.cs
@@ -1,18 +1,16 @@
 using System.Security.Claims;
 
-using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Diagnostics;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Options;
-
-using IHFiction.Data;
 using IHFiction.Data.Authors.Domain;
 using IHFiction.Data.Contexts;
 using IHFiction.Data.Stories.Domain;
 using IHFiction.FictionApi.Common;
 using IHFiction.FictionApi.Stories;
 using IHFiction.SharedKernel.Markdown;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
 
 using MongoDB.Bson;
 using MongoDB.Driver;
@@ -222,20 +220,9 @@ public sealed class UpdateStoryContentMarkdownTests : BaseIntegrationTest, IConf
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "xUnit1013:Public method should be marked as test", Justification = "This method implements IConfigureServices<T>")]
     public static void ConfigureServices(IServiceCollection services)
     {
-        services.AddKeyedScoped(
-            nameof(UpdateStoryContentMarkdownTests),
-            (sp, key) => new FictionDbContext(new DbContextOptionsBuilder<FictionDbContext>()
-                .UseNpgsql(sp.GetRequiredService<PgsqlConnectionStringProvider>().GetConnectionStringForDatabase($"test_{nameof(UpdateStoryContentMarkdownTests)}"))
-                .UseSnakeCaseNamingConvention()
-                .ConfigureWarnings(w => w.Log(RelationalEventId.PendingModelChangesWarning))
-                .WithDefaultInterceptors(sp.GetRequiredService<TimeProvider>())
-                .Options));
-
-        services.AddKeyedScoped(
-            nameof(UpdateStoryContentMarkdownTests),
-            (sp, key) => sp.GetRequiredService<IMongoClient>()
-                .GetDatabase($"test_stories_{nameof(UpdateStoryContentMarkdownTests)}")
-                .GetCollection<WorkBody>("works"));
+        services
+            .AddKeyedTestFictionDbContext<UpdateStoryContentMarkdownTests>()
+            .AddKeyedTestWorkBodyCollection<UpdateStoryContentMarkdownTests>();
     }
 
     public async ValueTask InitializeAsync()


### PR DESCRIPTION
### Motivation
- Remove duplicated `ConfigureServices` boilerplate across many integration tests by centralizing keyed test DI registrations. 
- Make it easier to configure per-test PostgreSQL options (e.g. split-query) and Mongo collections consistently while keeping existing per-test overrides. 

### Description
- Add `tests/IHFiction.IntegrationTests/IntegrationTestServiceCollectionExtensions.cs` with `AddKeyedTestFictionDbContext<TTest>` and `AddKeyedTestWorkBodyCollection<TTest>` helpers to register keyed `FictionDbContext` and keyed Mongo `WorkBody` collections. 
- Update multiple integration test files to replace inline `AddKeyedScoped` boilerplate with the new helpers and preserve per-test options via the helpers' parameters (e.g. `configureNpgsql`, `configurePendingModelWarning`, `useDefaultInterceptors`). 
- Apply formatting/final-newline fixes for the modified test files to satisfy repository style checks. 

### Testing
- Ran `dotnet restore tests/IHFiction.IntegrationTests/IHFiction.IntegrationTests.csproj` and the restore completed successfully. 
- Built the integration test project with `dotnet build tests/IHFiction.IntegrationTests/IHFiction.IntegrationTests.csproj --no-restore` and the build succeeded. 
- Verified formatting with `dotnet format ... --verify-no-changes` and ran `git diff --check` with no outstanding style errors. 
- Attempted to run integration tests (`dotnet run` / `dotnet test`), but execution was blocked in this environment because Testcontainers/Docker could not connect to the Docker endpoint (`/var/run/docker.sock`), so test execution against real containers was not possible here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06a97a7fc08333abb6577f305fa15b)