### PR TITLE
Refactor duplicated device identifier errors

### DIFF
--- a/src/IHFiction.FictionApi/Authors/FollowAuthor.cs
+++ b/src/IHFiction.FictionApi/Authors/FollowAuthor.cs
@@ -151,9 +151,6 @@ internal sealed class UnfollowAuthor(
 
 internal sealed class FollowAuthorForDevice(FictionDbContext context) : IUseCase, INameEndpoint<FollowAuthorForDevice>
 {
-    internal static readonly DomainError InvalidDeviceId =
-        new("Device.InvalidIdentifier", "A valid device identifier is required.");
-
     internal sealed record FollowAuthorForDeviceQuery(
         [property: StringLength(50, ErrorMessage = "Fields must be 50 characters or less.")]
         [property: ShapesType<FollowAuthorForDeviceResponse>]
@@ -167,7 +164,7 @@ internal sealed class FollowAuthorForDevice(FictionDbContext context) : IUseCase
         string? deviceId,
         CancellationToken cancellationToken = default)
     {
-        if (!DeviceIdHeader.IsValid(deviceId)) return InvalidDeviceId;
+        if (!DeviceIdHeader.IsValid(deviceId)) return CommonErrors.Device.InvalidIdentifier;
 
         var exists = await context.Authors.AnyAsync(author => author.Id == id, cancellationToken);
         if (!exists) return CommonErrors.Author.NotFound;
@@ -219,9 +216,6 @@ internal sealed class FollowAuthorForDevice(FictionDbContext context) : IUseCase
 
 internal sealed class UnfollowAuthorForDevice(FictionDbContext context) : IUseCase, INameEndpoint<UnfollowAuthorForDevice>
 {
-    internal static readonly DomainError InvalidDeviceId =
-        new("Device.InvalidIdentifier", "A valid device identifier is required.");
-
     internal sealed record UnfollowAuthorForDeviceQuery(
         [property: StringLength(50, ErrorMessage = "Fields must be 50 characters or less.")]
         [property: ShapesType<UnfollowAuthorForDeviceResponse>]
@@ -235,7 +229,7 @@ internal sealed class UnfollowAuthorForDevice(FictionDbContext context) : IUseCa
         string? deviceId,
         CancellationToken cancellationToken = default)
     {
-        if (!DeviceIdHeader.IsValid(deviceId)) return InvalidDeviceId;
+        if (!DeviceIdHeader.IsValid(deviceId)) return CommonErrors.Device.InvalidIdentifier;
 
         var exists = await context.Authors.AnyAsync(author => author.Id == id, cancellationToken);
         if (!exists) return CommonErrors.Author.NotFound;

--- a/src/IHFiction.FictionApi/Common/CommonErrors.cs
+++ b/src/IHFiction.FictionApi/Common/CommonErrors.cs
@@ -41,6 +41,14 @@ internal static class CommonErrors
     }
 
     /// <summary>
+    /// Device-related errors for anonymous browser or installed PWA device operations.
+    /// </summary>
+    internal static class Device
+    {
+        public static readonly DomainError InvalidIdentifier = new("Device.InvalidIdentifier", "A valid device identifier is required.");
+    }
+
+    /// <summary>
     /// Authentication and authorization errors.
     /// </summary>
     internal static class Auth

--- a/src/IHFiction.FictionApi/Notifications/GetDeviceFollows.cs
+++ b/src/IHFiction.FictionApi/Notifications/GetDeviceFollows.cs
@@ -14,9 +14,6 @@ namespace IHFiction.FictionApi.Notifications;
 
 internal sealed class GetDeviceFollows(FictionDbContext context) : IUseCase, INameEndpoint<GetDeviceFollows>
 {
-    internal static readonly DomainError InvalidDeviceId =
-        new("Device.InvalidIdentifier", "A valid device identifier is required.");
-
     internal sealed record GetDeviceFollowsQuery(
         [property: StringLength(50, ErrorMessage = "Fields must be 50 characters or less.")]
         [property: ShapesType<GetDeviceFollowsResponse>]
@@ -33,7 +30,7 @@ internal sealed class GetDeviceFollows(FictionDbContext context) : IUseCase, INa
         string? deviceId,
         CancellationToken cancellationToken = default)
     {
-        if (!DeviceIdHeader.IsValid(deviceId)) return InvalidDeviceId;
+        if (!DeviceIdHeader.IsValid(deviceId)) return CommonErrors.Device.InvalidIdentifier;
 
         var authors = await context.DeviceAuthorFollows
             .AsNoTracking()

--- a/src/IHFiction.FictionApi/Notifications/GetDeviceNotifications.cs
+++ b/src/IHFiction.FictionApi/Notifications/GetDeviceNotifications.cs
@@ -14,9 +14,6 @@ namespace IHFiction.FictionApi.Notifications;
 
 internal sealed class GetDeviceNotifications(FictionDbContext context) : IUseCase, INameEndpoint<GetDeviceNotifications>
 {
-    internal static readonly DomainError InvalidDeviceId =
-        new("Device.InvalidIdentifier", "A valid device identifier is required.");
-
     internal sealed record GetDeviceNotificationsQuery(
         [property: Range(1, 200, ErrorMessage = "Limit must be between 1 and 200.")]
         int Limit = 50,
@@ -50,7 +47,7 @@ internal sealed class GetDeviceNotifications(FictionDbContext context) : IUseCas
         GetDeviceNotificationsQuery query,
         CancellationToken cancellationToken = default)
     {
-        if (!DeviceIdHeader.IsValid(deviceId)) return InvalidDeviceId;
+        if (!DeviceIdHeader.IsValid(deviceId)) return CommonErrors.Device.InvalidIdentifier;
 
         var deliveries = await context.DeviceNotificationDeliveries
             .Where(delivery => delivery.DeviceId == deviceId)

--- a/src/IHFiction.FictionApi/Notifications/MarkDeviceNotificationRead.cs
+++ b/src/IHFiction.FictionApi/Notifications/MarkDeviceNotificationRead.cs
@@ -16,9 +16,6 @@ internal sealed class MarkDeviceNotificationRead(
     FictionDbContext context,
     TimeProvider timeProvider) : IUseCase, INameEndpoint<MarkDeviceNotificationRead>
 {
-    internal static readonly DomainError InvalidDeviceId =
-        new("Device.InvalidIdentifier", "A valid device identifier is required.");
-
     internal static readonly DomainError NotificationNotFound =
         new("Notification.NotFound", "Notification not found.");
 
@@ -35,7 +32,7 @@ internal sealed class MarkDeviceNotificationRead(
         string? deviceId,
         CancellationToken cancellationToken = default)
     {
-        if (!DeviceIdHeader.IsValid(deviceId)) return InvalidDeviceId;
+        if (!DeviceIdHeader.IsValid(deviceId)) return CommonErrors.Device.InvalidIdentifier;
 
         var delivery = await context.DeviceNotificationDeliveries
             .FirstOrDefaultAsync(candidate => candidate.DeviceId == deviceId && candidate.NotificationId == id, cancellationToken);

--- a/src/IHFiction.FictionApi/Notifications/RegisterDevicePushSubscription.cs
+++ b/src/IHFiction.FictionApi/Notifications/RegisterDevicePushSubscription.cs
@@ -15,9 +15,6 @@ namespace IHFiction.FictionApi.Notifications;
 
 internal sealed class RegisterDevicePushSubscription(FictionDbContext context) : IUseCase, INameEndpoint<RegisterDevicePushSubscription>
 {
-    internal static readonly DomainError InvalidDeviceId =
-        new("Device.InvalidIdentifier", "A valid device identifier is required.");
-
     internal sealed record RegisterDevicePushSubscriptionBody(
         [property: Required]
         [property: StringLength(500)]
@@ -39,7 +36,7 @@ internal sealed class RegisterDevicePushSubscription(FictionDbContext context) :
         string? deviceId,
         CancellationToken cancellationToken = default)
     {
-        if (!DeviceIdHeader.IsValid(deviceId)) return InvalidDeviceId;
+        if (!DeviceIdHeader.IsValid(deviceId)) return CommonErrors.Device.InvalidIdentifier;
         if (!IsValid(body)) return RegisterOwnPushSubscription.InvalidSubscription;
 
         var subscription = await context.DevicePushSubscriptions

--- a/src/IHFiction.FictionApi/Stories/FollowStory.cs
+++ b/src/IHFiction.FictionApi/Stories/FollowStory.cs
@@ -159,9 +159,6 @@ internal sealed class UnfollowStory(
 
 internal sealed class FollowStoryForDevice(FictionDbContext context) : IUseCase, INameEndpoint<FollowStoryForDevice>
 {
-    internal static readonly DomainError InvalidDeviceId =
-        new("Device.InvalidIdentifier", "A valid device identifier is required.");
-
     internal sealed record FollowStoryForDeviceQuery(
         [property: StringLength(50, ErrorMessage = "Fields must be 50 characters or less.")]
         [property: ShapesType<FollowStoryForDeviceResponse>]
@@ -175,7 +172,7 @@ internal sealed class FollowStoryForDevice(FictionDbContext context) : IUseCase,
         string? deviceId,
         CancellationToken cancellationToken = default)
     {
-        if (!DeviceIdHeader.IsValid(deviceId)) return InvalidDeviceId;
+        if (!DeviceIdHeader.IsValid(deviceId)) return CommonErrors.Device.InvalidIdentifier;
 
         var story = await context.Stories
             .AsNoTracking()
@@ -231,9 +228,6 @@ internal sealed class FollowStoryForDevice(FictionDbContext context) : IUseCase,
 
 internal sealed class UnfollowStoryForDevice(FictionDbContext context) : IUseCase, INameEndpoint<UnfollowStoryForDevice>
 {
-    internal static readonly DomainError InvalidDeviceId =
-        new("Device.InvalidIdentifier", "A valid device identifier is required.");
-
     internal sealed record UnfollowStoryForDeviceQuery(
         [property: StringLength(50, ErrorMessage = "Fields must be 50 characters or less.")]
         [property: ShapesType<UnfollowStoryForDeviceResponse>]
@@ -247,7 +241,7 @@ internal sealed class UnfollowStoryForDevice(FictionDbContext context) : IUseCas
         string? deviceId,
         CancellationToken cancellationToken = default)
     {
-        if (!DeviceIdHeader.IsValid(deviceId)) return InvalidDeviceId;
+        if (!DeviceIdHeader.IsValid(deviceId)) return CommonErrors.Device.InvalidIdentifier;
 
         var story = await context.Stories
             .AsNoTracking()


### PR DESCRIPTION
### Motivation
- Several device-related endpoints repeated the same `InvalidDeviceId` DomainError locally, creating duplicated code and risk of inconsistent messages across device flows.
- Centralizing the error into `CommonErrors` reduces repetition and makes the device validation error a single authoritative source.

### Description
- Add `internal static class Device` to `src/IHFiction.FictionApi/Common/CommonErrors.cs` with `InvalidIdentifier = new("Device.InvalidIdentifier", "A valid device identifier is required.")`.
- Remove per-file `internal static readonly DomainError InvalidDeviceId` declarations and replace `return InvalidDeviceId;` with `return CommonErrors.Device.InvalidIdentifier;` in device-focused handlers.
- Files updated: `Authors/FollowAuthor.cs`, `Stories/FollowStory.cs`, `Notifications/RegisterDevicePushSubscription.cs`, `Notifications/GetDeviceFollows.cs`, `Notifications/GetDeviceNotifications.cs`, and `Notifications/MarkDeviceNotificationRead.cs`.
- Changes are committed as one local commit on branch `dry-refactor/notification-read-helper` (`bcfce89 Refactor device identifier errors`).

### Testing
- Ran `dotnet build src/IHFiction.FictionApi/IHFiction.FictionApi.csproj` which succeeded after restore and produced the API assembly and `openapi.json`.
- Attempted `dotnet test tests/IHFiction.UnitTests/IHFiction.UnitTests.csproj --no-restore` which could not run because `global.json` requires `Microsoft.Testing.Platform` while the test project targets VSTest.
- `git diff --check` and repository checks ran and reported no whitespace or merge errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a073c52675483338def4a1353eca06a)