### PR TITLE
Refactor metadata URL formatting duplication

### DIFF
--- a/src/IHFiction.WebClient/Program.cs
+++ b/src/IHFiction.WebClient/Program.cs
@@ -112,6 +112,7 @@ builder.Services.AddScoped<ReaderProgressService>();
 builder.Services.AddScoped<ThemeService>();
 builder.Services.AddScoped<ViewPreferencesService>();
 builder.Services.AddScoped<StoryEditorService>();
+builder.Services.AddScoped<MetadataUrlService>();
 builder.Services.AddCascadingAuthenticationState();
 
 builder.Services.AddRazorComponents()

--- a/src/lib/IHFiction.SharedWeb/Components/Authors/AuthorDetail.razor
+++ b/src/lib/IHFiction.SharedWeb/Components/Authors/AuthorDetail.razor
@@ -2,7 +2,7 @@
 @using IHFiction.SharedWeb.Components.Stories
 @inject AuthorService AuthorService
 @inject MarkdownPipeline mdp
-@inject Microsoft.Extensions.Options.IOptions<IHFiction.SharedWeb.Configuration.SiteUrlOptions> SiteUrlOptions
+@inject MetadataUrlService MetadataUrls
 @using IHFiction.SharedWeb.Components.Notifications
 
 <SocialPreviewMetadata
@@ -232,36 +232,7 @@ else if (author != null)
         }
     }
 
-    private string ToAbsolute(string url)
-    {
-        var candidate = url.Trim();
-
-        if (Uri.TryCreate(candidate, UriKind.Absolute, out var absoluteUri))
-        {
-            if (!string.Equals(absoluteUri.Scheme, Uri.UriSchemeFile, StringComparison.OrdinalIgnoreCase))
-            {
-                return absoluteUri.ToString();
-            }
-
-            candidate = string.IsNullOrWhiteSpace(absoluteUri.PathAndQuery)
-                ? "/"
-                : string.Concat(absoluteUri.PathAndQuery, absoluteUri.Fragment);
-        }
-
-        return new Uri(GetMetadataBaseUri(), candidate).ToString();
-    }
-
-    private Uri GetMetadataBaseUri()
-    {
-        var baseUri = SiteUrlOptions.Value.BaseUrl;
-
-        if (baseUri is null)
-        {
-            throw new InvalidOperationException("BaseUrl must be configured as an absolute URL.");
-        }
-
-        return baseUri;
-    }
+    private string ToAbsolute(string url) => MetadataUrls.ToAbsolute(url);
 
     protected override async Task OnInitializedAsync()
     {

--- a/src/lib/IHFiction.SharedWeb/Components/Reading/ChapterReader.razor
+++ b/src/lib/IHFiction.SharedWeb/Components/Reading/ChapterReader.razor
@@ -1,7 +1,7 @@
 @using Markdig
 @inject ChapterService ChapterService
 @inject MarkdownPipeline mdp
-@inject Microsoft.Extensions.Options.IOptions<IHFiction.SharedWeb.Configuration.SiteUrlOptions> SiteUrlOptions
+@inject MetadataUrlService MetadataUrls
 
 <SocialPreviewMetadata
     Title="@MetadataTitle"
@@ -278,34 +278,5 @@ else if (chapterContent != null)
 
     private string ChapterHref(string chapterId) => $"/stories/{StoryId}/chapters/{chapterId}";
 
-    private string ToAbsolute(string url)
-    {
-        var candidate = url.Trim();
-
-        if (Uri.TryCreate(candidate, UriKind.Absolute, out var absoluteUri))
-        {
-            if (!string.Equals(absoluteUri.Scheme, Uri.UriSchemeFile, StringComparison.OrdinalIgnoreCase))
-            {
-                return absoluteUri.ToString();
-            }
-
-            candidate = string.IsNullOrWhiteSpace(absoluteUri.PathAndQuery)
-                ? "/"
-                : string.Concat(absoluteUri.PathAndQuery, absoluteUri.Fragment);
-        }
-
-        return new Uri(GetMetadataBaseUri(), candidate).ToString();
-    }
-
-    private Uri GetMetadataBaseUri()
-    {
-        var baseUri = SiteUrlOptions.Value.BaseUrl;
-
-        if (baseUri is null)
-        {
-            throw new InvalidOperationException("BaseUrl must be configured as an absolute URL.");
-        }
-
-        return baseUri;
-    }
+    private string ToAbsolute(string url) => MetadataUrls.ToAbsolute(url);
 }

--- a/src/lib/IHFiction.SharedWeb/Components/SocialPreviewMetadata.razor
+++ b/src/lib/IHFiction.SharedWeb/Components/SocialPreviewMetadata.razor
@@ -1,7 +1,5 @@
-@using IHFiction.SharedWeb.Configuration
-@using Microsoft.Extensions.Options
 @inject NavigationManager Nav
-@inject IOptions<SiteUrlOptions> SiteUrlOptions
+@inject MetadataUrlService MetadataUrls
 
 <PageTitle>@ResolvedTitle</PageTitle>
 
@@ -60,55 +58,11 @@
     private string SafeTitle => ResolvedTitle.Replace("❤️", "Heart");
     private string ResolvedDescription => Normalize(Description, 200, "Read stories and discover authors on IHeartFiction.");
     private string ResolvedTwitterDescription => Normalize(Description, 199, "Read stories and discover authors on IHeartFiction.");
-    private string ResolvedPageUrl => ToAbsolute(PageUrl ?? GetCurrentPathAndQuery());
-    private string ResolvedCanonicalUrl => ToAbsolute(CanonicalUrl ?? ResolvedPageUrl);
-    private string? ResolvedPreviousUrl => ToAbsoluteOrNull(PreviousUrl);
-    private string? ResolvedNextUrl => ToAbsoluteOrNull(NextUrl);
-    private string ResolvedImageUrl => ToAbsolute(ImageUrl ?? DefaultImagePath);
-
-    private Uri MetadataBaseUri => GetMetadataBaseUri();
-
-    private string ToAbsolute(string url)
-    {
-        var candidate = url.Trim();
-
-        if (Uri.TryCreate(candidate, UriKind.Absolute, out var absoluteUri))
-        {
-            // Keep explicit HTTP(S) absolute URLs as-is.
-            if (!string.Equals(absoluteUri.Scheme, Uri.UriSchemeFile, StringComparison.OrdinalIgnoreCase))
-            {
-                return absoluteUri.ToString();
-            }
-
-            candidate = string.IsNullOrWhiteSpace(absoluteUri.PathAndQuery)
-                ? "/"
-                : string.Concat(absoluteUri.PathAndQuery, absoluteUri.Fragment);
-        }
-
-        return new Uri(MetadataBaseUri, candidate).ToString();
-    }
-
-    private string? ToAbsoluteOrNull(string? url)
-    {
-        if (string.IsNullOrWhiteSpace(url))
-        {
-            return null;
-        }
-
-        return ToAbsolute(url);
-    }
-
-    private Uri GetMetadataBaseUri()
-    {
-        var baseUri = SiteUrlOptions.Value.BaseUrl;
-
-        if (baseUri is null)
-        {
-            throw new InvalidOperationException("BaseUrl must be configured as an absolute URL.");
-        }
-
-        return baseUri;
-    }
+    private string ResolvedPageUrl => MetadataUrls.ToAbsolute(PageUrl ?? GetCurrentPathAndQuery());
+    private string ResolvedCanonicalUrl => MetadataUrls.ToAbsolute(CanonicalUrl ?? ResolvedPageUrl);
+    private string? ResolvedPreviousUrl => MetadataUrls.ToAbsoluteOrNull(PreviousUrl);
+    private string? ResolvedNextUrl => MetadataUrls.ToAbsoluteOrNull(NextUrl);
+    private string ResolvedImageUrl => MetadataUrls.ToAbsolute(ImageUrl ?? DefaultImagePath);
 
     private string GetCurrentPathAndQuery()
     {

--- a/src/lib/IHFiction.SharedWeb/Components/Stories/StoryDetail.razor
+++ b/src/lib/IHFiction.SharedWeb/Components/Stories/StoryDetail.razor
@@ -1,6 +1,6 @@
 @using static IHFiction.Data.Stories.Domain.StoryType
 @inject StoryService StoryService
-@inject Microsoft.Extensions.Options.IOptions<IHFiction.SharedWeb.Configuration.SiteUrlOptions> SiteUrlOptions
+@inject MetadataUrlService MetadataUrls
 @using IHFiction.SharedWeb.Components.Notifications
 @using IHFiction.SharedWeb.Components.Reading
 
@@ -308,36 +308,7 @@ else if (story != null)
     // Helper to provide a non-null story id string for markup
     private string StoryIdString => story?.Id.ToString() ?? string.Empty;
 
-    private string ToAbsolute(string url)
-    {
-        var candidate = url.Trim();
-
-        if (Uri.TryCreate(candidate, UriKind.Absolute, out var absoluteUri))
-        {
-            if (!string.Equals(absoluteUri.Scheme, Uri.UriSchemeFile, StringComparison.OrdinalIgnoreCase))
-            {
-                return absoluteUri.ToString();
-            }
-
-            candidate = string.IsNullOrWhiteSpace(absoluteUri.PathAndQuery)
-                ? "/"
-                : string.Concat(absoluteUri.PathAndQuery, absoluteUri.Fragment);
-        }
-
-        return new Uri(GetMetadataBaseUri(), candidate).ToString();
-    }
-
-    private Uri GetMetadataBaseUri()
-    {
-        var baseUri = SiteUrlOptions.Value.BaseUrl;
-
-        if (baseUri is null)
-        {
-            throw new InvalidOperationException("BaseUrl must be configured as an absolute URL.");
-        }
-
-        return baseUri;
-    }
+    private string ToAbsolute(string url) => MetadataUrls.ToAbsolute(url);
 
     private List<ReaderChapterNavItem> BuildChapterItems()
     {

--- a/src/lib/IHFiction.SharedWeb/Pages/Authors.razor
+++ b/src/lib/IHFiction.SharedWeb/Pages/Authors.razor
@@ -1,5 +1,5 @@
 @using IHFiction.SharedWeb.Components.Authors
-@inject Microsoft.Extensions.Options.IOptions<IHFiction.SharedWeb.Configuration.SiteUrlOptions> SiteUrlOptions
+@inject MetadataUrlService MetadataUrls
 
 @page "/authors"
 
@@ -32,34 +32,5 @@
         ["url"] = ToAbsolute(CanonicalUrl)
     };
 
-    private string ToAbsolute(string path)
-    {
-        var candidate = path.Trim();
-
-        if (Uri.TryCreate(candidate, UriKind.Absolute, out var absoluteUri))
-        {
-            if (!string.Equals(absoluteUri.Scheme, Uri.UriSchemeFile, StringComparison.OrdinalIgnoreCase))
-            {
-                return absoluteUri.ToString();
-            }
-
-            candidate = string.IsNullOrWhiteSpace(absoluteUri.PathAndQuery)
-                ? "/"
-                : string.Concat(absoluteUri.PathAndQuery, absoluteUri.Fragment);
-        }
-
-        return new Uri(GetMetadataBaseUri(), candidate).ToString();
-    }
-
-    private Uri GetMetadataBaseUri()
-    {
-        var baseUri = SiteUrlOptions.Value.BaseUrl;
-
-        if (baseUri is null)
-        {
-            throw new InvalidOperationException("BaseUrl must be configured as an absolute URL.");
-        }
-
-        return baseUri;
-    }
+    private string ToAbsolute(string path) => MetadataUrls.ToAbsolute(path);
 }

--- a/src/lib/IHFiction.SharedWeb/Pages/Home.razor
+++ b/src/lib/IHFiction.SharedWeb/Pages/Home.razor
@@ -1,6 +1,6 @@
 @page "/"
 @using Sidio.Sitemap.Core
-@inject Microsoft.Extensions.Options.IOptions<IHFiction.SharedWeb.Configuration.SiteUrlOptions> SiteUrlOptions
+@inject MetadataUrlService MetadataUrls
 
 @attribute [Sitemap(ChangeFrequency.Yearly, 0.5, "2025-10-02")]
 
@@ -63,44 +63,13 @@
             ["potentialAction"] = new Dictionary<string, object?>
             {
                 ["@type"] = "SearchAction",
-                ["target"] = $"{MetadataBaseUri.ToString().TrimEnd('/')}/stories?q={{search_term_string}}",
+                ["target"] = $"{MetadataUrls.BaseUri.ToString().TrimEnd('/')}/stories?q={{search_term_string}}",
                 ["query-input"] = "required name=search_term_string"
             }
         }
     ];
 
-    private Uri MetadataBaseUri => GetMetadataBaseUri();
-
-    private string ToAbsolute(string url)
-    {
-        var candidate = url.Trim();
-
-        if (Uri.TryCreate(candidate, UriKind.Absolute, out var absoluteUri))
-        {
-            if (!string.Equals(absoluteUri.Scheme, Uri.UriSchemeFile, StringComparison.OrdinalIgnoreCase))
-            {
-                return absoluteUri.ToString();
-            }
-
-            candidate = string.IsNullOrWhiteSpace(absoluteUri.PathAndQuery)
-                ? "/"
-                : string.Concat(absoluteUri.PathAndQuery, absoluteUri.Fragment);
-        }
-
-        return new Uri(MetadataBaseUri, candidate).ToString();
-    }
-
-    private Uri GetMetadataBaseUri()
-    {
-        var baseUri = SiteUrlOptions.Value.BaseUrl;
-
-        if (baseUri is null)
-        {
-            throw new InvalidOperationException("BaseUrl must be configured as an absolute URL.");
-        }
-
-        return baseUri;
-    }
+    private string ToAbsolute(string url) => MetadataUrls.ToAbsolute(url);
 }
 
 <section class="section">

--- a/src/lib/IHFiction.SharedWeb/Pages/Stories.razor
+++ b/src/lib/IHFiction.SharedWeb/Pages/Stories.razor
@@ -1,5 +1,5 @@
 @using IHFiction.SharedWeb.Components.Stories
-@inject Microsoft.Extensions.Options.IOptions<IHFiction.SharedWeb.Configuration.SiteUrlOptions> SiteUrlOptions
+@inject MetadataUrlService MetadataUrls
 
 @page "/stories"
 
@@ -33,34 +33,5 @@
         ["url"] = ToAbsolute(CanonicalUrl)
     };
 
-    private string ToAbsolute(string path)
-    {
-        var candidate = path.Trim();
-
-        if (Uri.TryCreate(candidate, UriKind.Absolute, out var absoluteUri))
-        {
-            if (!string.Equals(absoluteUri.Scheme, Uri.UriSchemeFile, StringComparison.OrdinalIgnoreCase))
-            {
-                return absoluteUri.ToString();
-            }
-
-            candidate = string.IsNullOrWhiteSpace(absoluteUri.PathAndQuery)
-                ? "/"
-                : string.Concat(absoluteUri.PathAndQuery, absoluteUri.Fragment);
-        }
-
-        return new Uri(GetMetadataBaseUri(), candidate).ToString();
-    }
-
-    private Uri GetMetadataBaseUri()
-    {
-        var baseUri = SiteUrlOptions.Value.BaseUrl;
-
-        if (baseUri is null)
-        {
-            throw new InvalidOperationException("BaseUrl must be configured as an absolute URL.");
-        }
-
-        return baseUri;
-    }
+    private string ToAbsolute(string path) => MetadataUrls.ToAbsolute(path);
 }

--- a/src/lib/IHFiction.SharedWeb/Services/MetadataUrlService.cs
+++ b/src/lib/IHFiction.SharedWeb/Services/MetadataUrlService.cs
@@ -41,9 +41,14 @@ public sealed class MetadataUrlService(IOptions<SiteUrlOptions> siteUrlOptions)
 
         if (uri.IsAbsoluteUri)
         {
-            if (!string.Equals(uri.Scheme, Uri.UriSchemeFile, StringComparison.OrdinalIgnoreCase))
+            if (IsHttpScheme(uri))
             {
                 return uri.ToString();
+            }
+
+            if (!string.Equals(uri.Scheme, Uri.UriSchemeFile, StringComparison.OrdinalIgnoreCase))
+            {
+                throw new InvalidOperationException("Metadata URLs must use HTTP(S) or be relative paths.");
             }
 
             var candidate = string.IsNullOrWhiteSpace(uri.PathAndQuery)
@@ -59,8 +64,24 @@ public sealed class MetadataUrlService(IOptions<SiteUrlOptions> siteUrlOptions)
     public string? ToAbsoluteOrNull(string? pathOrUrl) =>
         string.IsNullOrWhiteSpace(pathOrUrl)
             ? null
-            : ToAbsolute(new Uri(pathOrUrl.Trim(), UriKind.RelativeOrAbsolute));
+            : ToAbsoluteOrNull(new Uri(pathOrUrl.Trim(), UriKind.RelativeOrAbsolute));
 
-    public string? ToAbsoluteOrNull(Uri? uri) =>
-        uri is null ? null : ToAbsolute(uri);
+    public string? ToAbsoluteOrNull(Uri? uri)
+    {
+        if (uri is null)
+        {
+            return null;
+        }
+
+        if (uri.IsAbsoluteUri && !IsHttpScheme(uri) && !string.Equals(uri.Scheme, Uri.UriSchemeFile, StringComparison.OrdinalIgnoreCase))
+        {
+            return null;
+        }
+
+        return ToAbsolute(uri);
+    }
+
+    private static bool IsHttpScheme(Uri uri) =>
+        string.Equals(uri.Scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase) ||
+        string.Equals(uri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase);
 }

--- a/src/lib/IHFiction.SharedWeb/Services/MetadataUrlService.cs
+++ b/src/lib/IHFiction.SharedWeb/Services/MetadataUrlService.cs
@@ -25,7 +25,14 @@ public sealed class MetadataUrlService(IOptions<SiteUrlOptions> siteUrlOptions)
     {
         ArgumentNullException.ThrowIfNull(pathOrUrl);
 
-        return ToAbsolute(new Uri(pathOrUrl.Trim(), UriKind.RelativeOrAbsolute));
+        var normalizedPathOrUrl = pathOrUrl.Trim();
+
+        if (normalizedPathOrUrl.Length == 0)
+        {
+            return BaseUri.ToString();
+        }
+
+        return ToAbsolute(new Uri(normalizedPathOrUrl, UriKind.RelativeOrAbsolute));
     }
 
     public string ToAbsolute(Uri uri)

--- a/src/lib/IHFiction.SharedWeb/Services/MetadataUrlService.cs
+++ b/src/lib/IHFiction.SharedWeb/Services/MetadataUrlService.cs
@@ -14,7 +14,7 @@ public sealed class MetadataUrlService(IOptions<SiteUrlOptions> siteUrlOptions)
 
             if (baseUri is null)
             {
-                throw new InvalidOperationException("BaseUrl must be configured as an absolute URL.");
+                throw new InvalidOperationException("BaseUrl must be configured as an absolute HTTP(S) URL.");
             }
 
             return baseUri;

--- a/src/lib/IHFiction.SharedWeb/Services/MetadataUrlService.cs
+++ b/src/lib/IHFiction.SharedWeb/Services/MetadataUrlService.cs
@@ -46,7 +46,7 @@ public sealed class MetadataUrlService(IOptions<SiteUrlOptions> siteUrlOptions)
                 return uri.ToString();
             }
 
-            if (!string.Equals(uri.Scheme, Uri.UriSchemeFile, StringComparison.OrdinalIgnoreCase))
+            if (!IsFileScheme(uri))
             {
                 throw new InvalidOperationException("Metadata URLs must use HTTP(S) or be relative paths.");
             }
@@ -73,7 +73,7 @@ public sealed class MetadataUrlService(IOptions<SiteUrlOptions> siteUrlOptions)
             return null;
         }
 
-        if (uri.IsAbsoluteUri && !IsHttpScheme(uri) && !string.Equals(uri.Scheme, Uri.UriSchemeFile, StringComparison.OrdinalIgnoreCase))
+        if (uri.IsAbsoluteUri && !IsSupportedAbsoluteScheme(uri))
         {
             return null;
         }
@@ -81,7 +81,13 @@ public sealed class MetadataUrlService(IOptions<SiteUrlOptions> siteUrlOptions)
         return ToAbsolute(uri);
     }
 
+    private static bool IsSupportedAbsoluteScheme(Uri uri) =>
+        IsHttpScheme(uri) || IsFileScheme(uri);
+
     private static bool IsHttpScheme(Uri uri) =>
         string.Equals(uri.Scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase) ||
         string.Equals(uri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase);
+
+    private static bool IsFileScheme(Uri uri) =>
+        string.Equals(uri.Scheme, Uri.UriSchemeFile, StringComparison.OrdinalIgnoreCase);
 }

--- a/src/lib/IHFiction.SharedWeb/Services/MetadataUrlService.cs
+++ b/src/lib/IHFiction.SharedWeb/Services/MetadataUrlService.cs
@@ -1,0 +1,59 @@
+using Microsoft.Extensions.Options;
+
+using IHFiction.SharedWeb.Configuration;
+
+namespace IHFiction.SharedWeb.Services;
+
+public sealed class MetadataUrlService(IOptions<SiteUrlOptions> siteUrlOptions)
+{
+    public Uri BaseUri
+    {
+        get
+        {
+            var baseUri = siteUrlOptions.Value.BaseUrl;
+
+            if (baseUri is null)
+            {
+                throw new InvalidOperationException("BaseUrl must be configured as an absolute URL.");
+            }
+
+            return baseUri;
+        }
+    }
+
+    public string ToAbsolute(string pathOrUrl)
+    {
+        ArgumentNullException.ThrowIfNull(pathOrUrl);
+
+        return ToAbsolute(new Uri(pathOrUrl.Trim(), UriKind.RelativeOrAbsolute));
+    }
+
+    public string ToAbsolute(Uri uri)
+    {
+        ArgumentNullException.ThrowIfNull(uri);
+
+        if (uri.IsAbsoluteUri)
+        {
+            if (!string.Equals(uri.Scheme, Uri.UriSchemeFile, StringComparison.OrdinalIgnoreCase))
+            {
+                return uri.ToString();
+            }
+
+            var candidate = string.IsNullOrWhiteSpace(uri.PathAndQuery)
+                ? "/"
+                : string.Concat(uri.PathAndQuery, uri.Fragment);
+
+            return new Uri(BaseUri, candidate).ToString();
+        }
+
+        return new Uri(BaseUri, uri).ToString();
+    }
+
+    public string? ToAbsoluteOrNull(string? pathOrUrl) =>
+        string.IsNullOrWhiteSpace(pathOrUrl)
+            ? null
+            : ToAbsolute(new Uri(pathOrUrl.Trim(), UriKind.RelativeOrAbsolute));
+
+    public string? ToAbsoluteOrNull(Uri? uri) =>
+        uri is null ? null : ToAbsolute(uri);
+}

--- a/tests/IHFiction.UnitTests/SharedWeb/MetadataUrlServiceTests.cs
+++ b/tests/IHFiction.UnitTests/SharedWeb/MetadataUrlServiceTests.cs
@@ -51,23 +51,29 @@ public sealed class MetadataUrlServiceTests
         result.Should().Be("https://example.test/images/cover.png?size=lg#v1");
     }
 
-    [Fact]
-    public void ToAbsolute_WithUnsupportedAbsoluteScheme_Throws()
+    [Theory]
+    [InlineData("javascript:alert(1)")]
+    [InlineData("vbscript:msgbox(\"x\")")]
+    [InlineData("data:text/html,<script>alert(1)</script>")]
+    public void ToAbsolute_WithUnsupportedAbsoluteScheme_Throws(string input)
     {
         var sut = CreateSut();
 
-        var act = () => sut.ToAbsolute(new Uri("javascript:alert(1)", UriKind.Absolute));
+        var act = () => sut.ToAbsolute(new Uri(input, UriKind.Absolute));
 
         act.Should().Throw<InvalidOperationException>()
             .WithMessage("Metadata URLs must use HTTP(S) or be relative paths.");
     }
 
-    [Fact]
-    public void ToAbsoluteOrNull_WithUnsupportedAbsoluteScheme_ReturnsNull()
+    [Theory]
+    [InlineData("javascript:alert(1)")]
+    [InlineData("vbscript:msgbox(\"x\")")]
+    [InlineData("data:text/html,<script>alert(1)</script>")]
+    public void ToAbsoluteOrNull_WithUnsupportedAbsoluteScheme_ReturnsNull(string input)
     {
         var sut = CreateSut();
 
-        var result = sut.ToAbsoluteOrNull("javascript:alert(1)");
+        var result = sut.ToAbsoluteOrNull(input);
 
         result.Should().BeNull();
     }

--- a/tests/IHFiction.UnitTests/SharedWeb/MetadataUrlServiceTests.cs
+++ b/tests/IHFiction.UnitTests/SharedWeb/MetadataUrlServiceTests.cs
@@ -1,0 +1,87 @@
+using Microsoft.Extensions.Options;
+
+using FluentAssertions;
+
+using IHFiction.SharedWeb.Configuration;
+using IHFiction.SharedWeb.Services;
+
+namespace IHFiction.UnitTests.SharedWeb;
+
+public sealed class MetadataUrlServiceTests
+{
+    private static readonly Uri BaseUri = new("https://example.test/");
+
+    [Fact]
+    public void ToAbsolute_WithRelativePath_ReturnsAbsoluteUrl()
+    {
+        var sut = CreateSut();
+
+        var result = sut.ToAbsolute("/images/cover.png");
+
+        result.Should().Be("https://example.test/images/cover.png");
+    }
+
+    [Fact]
+    public void ToAbsolute_WithWhitespace_ReturnsBaseUrl()
+    {
+        var sut = CreateSut();
+
+        var result = sut.ToAbsolute("   ");
+
+        result.Should().Be("https://example.test/");
+    }
+
+    [Fact]
+    public void ToAbsolute_WithAbsoluteHttpUrl_PreservesInput()
+    {
+        var sut = CreateSut();
+
+        var result = sut.ToAbsolute("https://cdn.example.test/cover.png");
+
+        result.Should().Be("https://cdn.example.test/cover.png");
+    }
+
+    [Fact]
+    public void ToAbsolute_WithFileUri_ResolvesAgainstBaseUrl()
+    {
+        var sut = CreateSut();
+
+        var result = sut.ToAbsolute(new Uri("file:///images/cover.png?size=lg#v1"));
+
+        result.Should().Be("https://example.test/images/cover.png?size=lg#v1");
+    }
+
+    [Fact]
+    public void ToAbsolute_WithUnsupportedAbsoluteScheme_Throws()
+    {
+        var sut = CreateSut();
+
+        var act = () => sut.ToAbsolute(new Uri("javascript:alert(1)", UriKind.Absolute));
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("Metadata URLs must use HTTP(S) or be relative paths.");
+    }
+
+    [Fact]
+    public void ToAbsoluteOrNull_WithUnsupportedAbsoluteScheme_ReturnsNull()
+    {
+        var sut = CreateSut();
+
+        var result = sut.ToAbsoluteOrNull("javascript:alert(1)");
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void ToAbsoluteOrNull_WithUnsupportedUri_ReturnsNull()
+    {
+        var sut = CreateSut();
+
+        var result = sut.ToAbsoluteOrNull(new Uri("data:text/plain;base64,SGVsbG8=", UriKind.Absolute));
+
+        result.Should().BeNull();
+    }
+
+    private static MetadataUrlService CreateSut() =>
+        new(Options.Create(new SiteUrlOptions { BaseUrl = BaseUri }));
+}


### PR DESCRIPTION
## Summary
- Extracted shared metadata URL formatting into `MetadataUrlService` for absolute URL conversion and BaseUrl validation.
- Replaced duplicated `ToAbsolute` / `GetMetadataBaseUri` logic across social preview metadata, structured-data pages, and story/author/chapter detail components.
- Registered the service in the web client DI container.

## Candidate scoring
| candidate | remediation shape | instances | lines_saved | scope | ease | risk |
| --- | --- | ---: | ---: | --- | --- | --- |
| Metadata absolute URL formatting in Blazor metadata components | Utility for repetitive formatting tasks | 6 | ~160 | narrow | easy | low |
| Author/story follow buttons share subscription toggle flow | Base component or front-end service for common component logic | 2 | ~70 | moderate | medium | medium |
| WebClient service registrations in Program.cs | DI extensions to clean up Program.cs | 1 long cluster | ~40 | moderate | easy | low |

Selected the metadata URL formatter because it had the best ease/risk balance while removing a repeated behavioral helper from a narrow ownership area.

## Repeated instances addressed
- `SocialPreviewMetadata.razor`
- `Home.razor`
- `Stories.razor`
- `Authors.razor`
- `StoryDetail.razor`
- `ChapterReader.razor`
- `AuthorDetail.razor`

## Validation
- `dotnet build --no-restore src/IHFiction.WebClient/IHFiction.WebClient.csproj`

## Commit hygiene
- Confirmed `git log --oneline origin/main..HEAD` contains one commit: `fd9666c Refactor metadata URL formatting duplication`.
