### PR TITLE
Extract GravatarUrlBuilder and deduplicate avatar URL logic in Authors endpoints

### DIFF
--- a/src/IHFiction.FictionApi/Authors/GetAuthor.cs
+++ b/src/IHFiction.FictionApi/Authors/GetAuthor.cs
@@ -1,6 +1,4 @@
 ﻿using System.ComponentModel.DataAnnotations;
-using System.Security.Cryptography;
-using System.Text;
 using System.Runtime.Serialization;
 
 using Microsoft.AspNetCore.Mvc;
@@ -75,7 +73,7 @@ internal sealed class GetAuthor(FictionDbContext context) : IUseCase, INameEndpo
         return new GetAuthorResponse(
             author.UserId,
             author.Name,
-            BuildAvatarUrl(author.GravatarEmail),
+            GravatarUrlBuilder.BuildAvatarUrl(author.GravatarEmail),
             author.UpdatedAt,
             author.DeletedAt,
             new GaAuthorProfile(
@@ -85,28 +83,6 @@ internal sealed class GetAuthor(FictionDbContext context) : IUseCase, INameEndpo
                     .Select(link => new GaAuthorSocialLink(link.Type, link.Value))),
             publishedStories,
             totalStories);
-    }
-
-    private static string? BuildAvatarUrl(string? gravatarEmail)
-    {
-        if (string.IsNullOrWhiteSpace(gravatarEmail))
-        {
-            return null;
-        }
-
-        #pragma warning disable CA1308 // Gravatar canonicalization requires lowercase email and hash
-        var normalized = gravatarEmail.Trim().ToLowerInvariant();
-        #pragma warning restore CA1308
-
-        #pragma warning disable CA5351 // MD5 is required by Gravatar hashing protocol
-        var hashBytes = MD5.HashData(Encoding.UTF8.GetBytes(normalized));
-        #pragma warning restore CA5351
-
-        #pragma warning disable CA1308 // Gravatar canonicalization requires lowercase email and hash
-        var hash = Convert.ToHexString(hashBytes).ToLowerInvariant();
-        #pragma warning restore CA1308
-
-        return $"https://www.gravatar.com/avatar/{hash}?s=512&d=identicon&r=g";
     }
 
     public static string EndpointName => nameof(GetAuthor);

--- a/src/IHFiction.FictionApi/Authors/ListAuthors.cs
+++ b/src/IHFiction.FictionApi/Authors/ListAuthors.cs
@@ -1,6 +1,4 @@
 using System.ComponentModel.DataAnnotations;
-using System.Security.Cryptography;
-using System.Text;
 
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
@@ -99,7 +97,7 @@ internal sealed class ListAuthors(
             .Select(a => new ListAuthorsItem(
                 a.Id,
                 a.Name,
-                BuildAvatarUrl(a.GravatarEmail),
+                GravatarUrlBuilder.BuildAvatarUrl(a.GravatarEmail),
                 a.Profile.Bio ?? "",
                 a.CreatedAt,
                 a.UpdatedAt,
@@ -109,28 +107,6 @@ internal sealed class ListAuthors(
         // Execute paginated query using the centralized service
         return await paginator.ExecutePagedQueryAsync(proj, query, cancellationToken);
     }
-
-        private static string? BuildAvatarUrl(string? gravatarEmail)
-        {
-        if (string.IsNullOrWhiteSpace(gravatarEmail))
-        {
-            return null;
-        }
-
-    #pragma warning disable CA1308 // Gravatar canonicalization requires lowercase email and hash
-        var normalized = gravatarEmail.Trim().ToLowerInvariant();
-    #pragma warning restore CA1308
-
-    #pragma warning disable CA5351 // MD5 is required by Gravatar hashing protocol
-        var hashBytes = MD5.HashData(Encoding.UTF8.GetBytes(normalized));
-    #pragma warning restore CA5351
-
-    #pragma warning disable CA1308 // Gravatar canonicalization requires lowercase email and hash
-        var hash = Convert.ToHexString(hashBytes).ToLowerInvariant();
-    #pragma warning restore CA1308
-
-        return $"https://www.gravatar.com/avatar/{hash}?s=512&d=identicon&r=g";
-        }
 
     public static string EndpointName => nameof(ListAuthors);
 

--- a/src/IHFiction.FictionApi/Common/GravatarUrlBuilder.cs
+++ b/src/IHFiction.FictionApi/Common/GravatarUrlBuilder.cs
@@ -1,0 +1,29 @@
+using System.Security.Cryptography;
+using System.Text;
+
+namespace IHFiction.FictionApi.Common;
+
+internal static class GravatarUrlBuilder
+{
+    public static string? BuildAvatarUrl(string? gravatarEmail)
+    {
+        if (string.IsNullOrWhiteSpace(gravatarEmail))
+        {
+            return null;
+        }
+
+#pragma warning disable CA1308 // Gravatar canonicalization requires lowercase email and hash
+        var normalized = gravatarEmail.Trim().ToLowerInvariant();
+#pragma warning restore CA1308
+
+#pragma warning disable CA5351 // MD5 is required by Gravatar hashing protocol
+        var hashBytes = MD5.HashData(Encoding.UTF8.GetBytes(normalized));
+#pragma warning restore CA5351
+
+#pragma warning disable CA1308 // Gravatar canonicalization requires lowercase email and hash
+        var hash = Convert.ToHexString(hashBytes).ToLowerInvariant();
+#pragma warning restore CA1308
+
+        return $"https://www.gravatar.com/avatar/{hash}?s=512&d=identicon&r=g";
+    }
+}


### PR DESCRIPTION
### Motivation
- Consolidate duplicated Gravatar email normalization, MD5 hashing, and URL construction logic found in multiple author endpoints into a single helper to reduce repetition and maintenance surface. 
- Keep the change small, low-risk, and contained to the FictionApi surface so behavior is preserved while improving DRYness.

### Description
- Added a new helper `GravatarUrlBuilder` in `src/IHFiction.FictionApi/Common/GravatarUrlBuilder.cs` that centralizes normalization, MD5 hashing, and Gravatar URL generation via `BuildAvatarUrl`. 
- Updated `GetAuthor` (`src/IHFiction.FictionApi/Authors/GetAuthor.cs`) and `ListAuthors` (`src/IHFiction.FictionApi/Authors/ListAuthors.cs`) to call `GravatarUrlBuilder.BuildAvatarUrl(...)` and removed the duplicated private `BuildAvatarUrl` implementations and related low-level `using` statements. 

### Testing
- Ran the repository preflight script via `./tools/agent-bootstrap.sh`, which restored dependencies and printed the .NET SDK version successfully. 
- Built the API project with `dotnet build src/IHFiction.FictionApi/IHFiction.FictionApi.csproj --no-restore`, which initially failed due to an intermediate edit and was immediately corrected, and the final build succeeded with zero errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c7bb923808333ba5c911e1dffeae6)